### PR TITLE
Fix all to hearts bug

### DIFF
--- a/mods/jokers_of_neon_classic/src/specials/converter/all_cards_to_hearts.cairo
+++ b/mods/jokers_of_neon_classic/src/specials/converter/all_cards_to_hearts.cairo
@@ -1,30 +1,33 @@
 #[dojo::contract]
 pub mod special_all_cards_to_hearts {
     use jokers_of_neon_classic::specials::specials::SPECIAL_ALL_CARDS_TO_HEARTS_ID;
+    use jokers_of_neon_lib::constants::card::get_card;
+    use jokers_of_neon_lib::constants::utils::is_neon_card;
     use jokers_of_neon_lib::interfaces::base::ICardBase;
     use jokers_of_neon_lib::interfaces::cards::converter::ICardConverter;
     use jokers_of_neon_lib::models::card_type::CardType;
-    use jokers_of_neon_lib::models::data::card::{Card, Suit};
+    use jokers_of_neon_lib::models::data::card::{Card, CardTrait, Suit};
     use jokers_of_neon_lib::models::tracker::GameContext;
 
     #[abi(embed_v0)]
     impl AllCardsToHeartsConverter of ICardConverter<ContractState> {
         fn apply(ref self: ContractState, context: GameContext, cards: Span<Card>) -> Span<Card> {
-            let mut cards = cards;
             let mut result = array![];
-            loop {
-                match cards.pop_front() {
-                    Option::Some(card) => {
-                        let mut new_card = *card;
-                        if new_card.suit == Suit::Clubs
-                            || new_card.suit == Suit::Spades
-                            || new_card.suit == Suit::Diamonds {
-                            new_card.suit = Suit::Hearts;
-                        }
-                        result.append(new_card);
-                    },
-                    Option::None => { break; },
-                }
+            for card in cards {
+                let original_card = *card;
+                let new_card = if original_card.suit != Suit::Hearts
+                    && original_card.suit != Suit::Joker
+                    && original_card.suit != Suit::Wild {
+                    let new_id = CardTrait::generate_id(original_card.value, Suit::Hearts);
+                    if is_neon_card(original_card.id) {
+                        get_card(CardTrait::generate_neon_id(new_id))
+                    } else {
+                        get_card(new_id)
+                    }
+                } else {
+                    original_card
+                };
+                result.append(new_card);
             }
             result.span()
         }


### PR DESCRIPTION
                                                                                                                                  
## El problema                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                           
En converter.cairo, el sistema detecta si una carta fue convertida comparando IDs:                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                
  if prev_card.id != new_card.id {                                                                                                                                                                                                                                                                                              
      // emitir evento de conversión                                                                                                                                                                                                                                                                                            
  }                                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                
  El código original de all_cards_to_hearts solo mutaba el campo suit:                                                                                                                                                                                                                                                          
                                                            
  new_card.suit = Suit::Hearts;  // id sigue siendo, ej: id del 3 de Spades                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                
  Como el id no cambiaba, la detección nunca disparaba → cero eventos emitidos.                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                
  Esto no causaba problema cuando all_cards_to_hearts se usaba sola, porque el frontend puede operar en modo optimista (sabe que todas las cartas se convierten a Hearts sin necesitar eventos). Pero cuando se combina con neon_doctrine (que tiene un 30% random), el frontend debe esperar los eventos de la blockchain para 
  saber qué pasó — y los eventos de Hearts nunca llegaban.  
                                                                                                                                                                                                                                                                                                                                
  Efecto secundario: neon_doctrine genera IDs neon basándose en card.id. Como el id seguía siendo el del suit original, producía, por ejemplo, "neon 3 de Spades" en vez de "neon 3 de Hearts".                                                                                                                                 
   
  El fix                                                                                                                                                                                                                                                                                                                        
                                                            
  Reemplazar la mutación directa de suit por get_card(new_id) — que retorna un Card completo con todos los campos sincronizados (incluyendo id). Mismo patrón que usan relativity, neon_doctrine, etc.                                                                                                                          
   